### PR TITLE
Compilation fix for CCScheduler::scheduleSelector

### DIFF
--- a/cocos2dx/CCScheduler.cpp
+++ b/cocos2dx/CCScheduler.cpp
@@ -241,7 +241,7 @@ void CCScheduler::removeHashElement(_hashSelectorEntry *pElement)
 	free(pElement);
 }
 
-void CCScheduler::scheduleSelector(SEL_SCHEDULE pfnSelector, SelectorProtocol *pTarget, float fInterval, bool bPaused)
+void CCScheduler::scheduleSelector(SEL_SCHEDULE pfnSelector, SelectorProtocol *pTarget, ccTime fInterval, bool bPaused)
 {
 	CCAssert(pfnSelector, "");
 	CCAssert(pTarget, "");


### PR DESCRIPTION
There was a different declaration and definition for
CCScheduler::scheduleSelector - ccTime was not fully used.
