### PR TITLE
CCDXParticleSystemQuad - buffer overflow and potential leak fixes

### DIFF
--- a/cocos2dx/CCDrawingPrimitives.cpp
+++ b/cocos2dx/CCDrawingPrimitives.cpp
@@ -278,7 +278,7 @@ void CCDrawingPrimitive::initVertexBuffer(unsigned int numberOfPoints)
 	VertexType* verticesT = new VertexType[numberOfPoints];
 	if ( !verticesT )
 	{
-		//
+		return;
 	}
 	memset(verticesT, 0, (sizeof(VertexType) * numberOfPoints));
 	/*
@@ -309,6 +309,8 @@ void CCDrawingPrimitive::initVertexBuffer(unsigned int numberOfPoints)
 	result = CCID3D11Device->CreateBuffer(&vertexBufferDesc, &vertexData, &m_vertexBuffer);
 	if(FAILED(result))
 	{
+		// clean up allocated resources
+		delete[] verticesT;
 		return ;
 	}
 
@@ -375,7 +377,12 @@ void CCDrawingPrimitive::RenderVertexBuffer()
 	D3D11_MAPPED_SUBRESOURCE mappedResource;
 	VertexType* verticesPtr;
 	HRESULT result;
-	if(FAILED(CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource))){return ;}
+	if(FAILED(CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource)))
+	{
+		// clean up allocated resources
+		delete[] verticesTmp;
+		return;
+	}
 	verticesPtr = (VertexType*)mappedResource.pData;
 	memcpy(verticesPtr, (void*)verticesTmp, (sizeof(VertexType) * m_vertexAmount));
 	CCID3D11DeviceContext->Unmap(m_vertexBuffer, 0);
@@ -444,7 +451,12 @@ void CCDrawingPrimitive::RenderVertexBuffer3D()
 
 	D3D11_MAPPED_SUBRESOURCE mappedResource;
 	VertexType* verticesPtr;
-	if(FAILED(CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource))){return ;}
+	if(FAILED(CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource)))
+	{
+		// clean up allocated resources
+		delete[] verticesTmp;
+		return;
+	}
 	verticesPtr = (VertexType*)mappedResource.pData;
 	memcpy(verticesPtr, (void*)verticesTmp, (sizeof(VertexType) * m_vertexAmount));
 	CCID3D11DeviceContext->Unmap(m_vertexBuffer, 0);

--- a/cocos2dx/effects/CCGrid.cpp
+++ b/cocos2dx/effects/CCGrid.cpp
@@ -358,6 +358,7 @@ namespace cocos2d
 		// Now create the vertex buffer.
 		if(FAILED(CCID3D11Device->CreateBuffer(&vertexBufferDesc, NULL, &m_vertexBuffer)))
 		{
+			delete[] indices;
 			return ;
 		}
 

--- a/cocos2dx/misc_nodes/CCProgressTimer.cpp
+++ b/cocos2dx/misc_nodes/CCProgressTimer.cpp
@@ -676,6 +676,10 @@ void CCDXProgressTimer::initVertexBuffer(ccV2F_C4B_T2F *vertexData,int& vertexDa
 
 	
 	VertexType* vertices = new VertexType[tmpVertexDataCount];
+	if (!vertices)
+	{
+		return;
+	}
 	memset(vertices, 0, (sizeof(VertexType) * tmpVertexDataCount));
 	if(eType == kCCProgressTimerTypeRadialCCW || eType == kCCProgressTimerTypeRadialCW)
 	{

--- a/cocos2dx/misc_nodes/CCRibbon.cpp
+++ b/cocos2dx/misc_nodes/CCRibbon.cpp
@@ -476,7 +476,11 @@ void CCDXRibbonSegment::RenderVertexBuffer(CCfloat* verts,CCfloat* coords,CCubyt
 
 	D3D11_MAPPED_SUBRESOURCE mappedResource;
 	VertexType* verticesPtr;
-	if(FAILED(CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource))){return ;}
+	if(FAILED(CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource)))
+	{
+		delete[] verticesTmp;
+		return;
+	}
 	verticesPtr = (VertexType*)mappedResource.pData;
 	memcpy(verticesPtr, (void*)verticesTmp, (sizeof(VertexType) * 100));
 	CCID3D11DeviceContext->Unmap(m_vertexBuffer, 0);

--- a/cocos2dx/particle_nodes/CCParticleSystemQuad.cpp
+++ b/cocos2dx/particle_nodes/CCParticleSystemQuad.cpp
@@ -350,8 +350,8 @@ CCDXParticleSystemQuad::CCDXParticleSystemQuad()
 	m_matrixBuffer = 0;
 	m_indexBuffer = 0;
 	m_vertexBuffer = 0;
-	//assumed there has 100 particles first
-	m_uMaxTotalParticles = 100;
+	//there is no any allocated memory yet
+	m_uMaxTotalParticles = 0;
 
 	m_bIsInit = FALSE;
 }
@@ -464,6 +464,8 @@ void CCDXParticleSystemQuad::RenderVertexBuffer(ccV2F_C4B_T2F_Quad *quad,unsigne
 	result = CCID3D11DeviceContext->Map(m_vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource);
 	if(FAILED(result))
 	{
+		// clean up allocated resources
+		delete[] verticesTmp;
 		return ;
 	}
 	verticesPtr = (VertexType*)mappedResource.pData;
@@ -637,6 +639,7 @@ void CCDXParticleSystemQuad::Render(ccV2F_C4B_T2F_Quad *quad,unsigned short* ind
 	{
 		m_bIsInit = TRUE;
 		FreeBuffer();
+		m_uMaxTotalParticles = uTotalParticles;
 		initVertexAndIndexBuffer(indices, uTotalParticles);
 		InitializeShader();
 	}

--- a/tests/tests/BugsTest/BugsTest.cpp
+++ b/tests/tests/BugsTest/BugsTest.cpp
@@ -8,6 +8,7 @@
 #include "Bug-914.h"
 #include "Bug-1159.h"
 #include "Bug-1174.h"
+#include "ParticleBufOverflow.h"
 
 #define TEST_BUG(bugNO)                                 \
 {                                                       \
@@ -21,7 +22,7 @@ pLayer->autorelease();                                  \
 
 enum
 {
-    MAX_COUNT = 9,
+    MAX_COUNT = 10,
     LINE_SPACE = 40,
     kItemTagBasic = 5432,
 };
@@ -38,7 +39,8 @@ const std::string testsName[MAX_COUNT] =
     "Bug-899",
     "Bug-914",
     "Bug-1159",
-    "Bug-1174"
+    "Bug-1174",
+    "Particle Buffer Overflow"
 };
 
 ////////////////////////////////////////////////////////
@@ -100,6 +102,9 @@ void BugsTestMainLayer::menuCallback(CCObject* pSender)
         break;
     case 8:
         TEST_BUG(1174);
+        break;
+    case 9:
+        TEST_BUG(ParticleBufOverflow);
         break;
     default:
         break;

--- a/tests/tests/BugsTest/ParticleBufOverflow.cpp
+++ b/tests/tests/BugsTest/ParticleBufOverflow.cpp
@@ -1,0 +1,48 @@
+/*
+  Buffer overflow on CCParticlesSystemQuad:
+  Should be first action, no any previous CCParticlesSystemQuad should be created.
+  a) Create an object with less than 99 particles (should be rendered first)
+  b) Create another object with more particles (and less than 100).
+  c) Check the behaviour
+
+  Two possibilities.
+  1) In case if video driver is protected against buffer overflow
+     D3D11 WARNING: ID3D11DeviceContext::DrawIndexed: Index buffer has not enough space! 
+	 [ EXECUTION WARNING #359: DEVICE_DRAW_INDEX_BUFFER_TOO_SMALL]
+     visually - some flickering is possible, partially displayed particles and so on
+
+  2) If memory (heap or something else) is really overwritten
+     Random crashes, undefined behaviour
+
+  Created by Denis Mingulov on 01.09.2012.
+*/
+
+#include "ParticleBufOverflow.h"
+#include "../testResource.h"
+
+bool BugParticleBufOverflowLayer::init()
+{
+    if (BugsTestBaseLayer::init())
+    {
+        CCSize size = CCDirector::sharedDirector()->getWinSize();
+
+		CCParticleFlower *first = new CCParticleFlower();
+	    first->setTexture( CCTextureCache::sharedTextureCache()->addImage(s_stars1) );
+		first->initWithTotalParticles(5);
+		first->autorelease();
+		first->setPosition(ccp(size.width/4, size.height/4));
+		addChild(first);
+
+
+		CCParticleFlower *second = new CCParticleFlower();
+	    second->setTexture( CCTextureCache::sharedTextureCache()->addImage(s_stars2) );
+		second->initWithTotalParticles(99);
+		second->autorelease();
+		second->setPosition(ccp(size.width*3/4, size.height*3/4));
+		addChild(second);
+
+        return true;
+	}
+
+	return false;
+}

--- a/tests/tests/BugsTest/ParticleBufOverflow.h
+++ b/tests/tests/BugsTest/ParticleBufOverflow.h
@@ -1,0 +1,12 @@
+#ifndef __BUG_PARTICLE_BUFOVERFLOW
+#define __BUG_PARTICLE_BUFOVERFLOW
+
+#include "BugsTest.h"
+
+class BugParticleBufOverflowLayer : public BugsTestBaseLayer
+{
+public:
+    virtual bool init();
+};
+
+#endif

--- a/tests/win8_metro/Cocos2d_win8_metro.vcxproj
+++ b/tests/win8_metro/Cocos2d_win8_metro.vcxproj
@@ -295,6 +295,7 @@
     <ClInclude Include="..\..\tests\tests\BugsTest\Bug-899.h" />
     <ClInclude Include="..\..\tests\tests\BugsTest\Bug-914.h" />
     <ClInclude Include="..\..\tests\tests\BugsTest\BugsTest.h" />
+    <ClInclude Include="..\..\tests\tests\BugsTest\ParticleBufOverflow.h" />
     <ClInclude Include="..\..\tests\tests\ClickAndMoveTest\ClickAndMoveTest.h" />
     <ClInclude Include="..\..\tests\tests\CocosDenshionTest\CocosDenshionTest.h" />
     <ClInclude Include="..\..\tests\tests\CocosNodeTest\CocosNodeTest.h" />
@@ -551,6 +552,7 @@
     <ClCompile Include="..\..\tests\tests\BugsTest\Bug-899.cpp" />
     <ClCompile Include="..\..\tests\tests\BugsTest\Bug-914.cpp" />
     <ClCompile Include="..\..\tests\tests\BugsTest\BugsTest.cpp" />
+    <ClCompile Include="..\..\tests\tests\BugsTest\ParticleBufOverflow.cpp" />
     <ClCompile Include="..\..\tests\tests\ClickAndMoveTest\ClickAndMoveTest.cpp" />
     <ClCompile Include="..\..\tests\tests\CocosDenshionTest\CocosDenshionTest.cpp" />
     <ClCompile Include="..\..\tests\tests\CocosNodeTest\CocosNodeTest.cpp" />

--- a/tests/win8_metro/Cocos2d_win8_metro.vcxproj.filters
+++ b/tests/win8_metro/Cocos2d_win8_metro.vcxproj.filters
@@ -1100,6 +1100,9 @@
     <ClInclude Include="..\..\tests\tests\BugsTest\BugsTest.h">
       <Filter>Classes\tests\BugsTest</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\tests\tests\BugsTest\ParticleBufOverflow.h">
+      <Filter>Classes\tests\BugsTest</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\tests\tests\BugsTest\Bug-458\Bug-458.h">
       <Filter>Classes\tests\BugsTest\Bug-458</Filter>
     </ClInclude>
@@ -1862,6 +1865,9 @@
       <Filter>Classes\tests\BugsTest</Filter>
     </ClCompile>
     <ClCompile Include="..\..\tests\tests\BugsTest\BugsTest.cpp">
+      <Filter>Classes\tests\BugsTest</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tests\tests\BugsTest\ParticleBufOverflow.cpp">
       <Filter>Classes\tests\BugsTest</Filter>
     </ClCompile>
     <ClCompile Include="..\..\tests\tests\BugsTest\Bug-458\Bug-458.cpp">


### PR DESCRIPTION
Briefly, due to the buffer overflow at CCDXParticleSystemQuad - it was impossible to use more than 1 CCDXParticleSystemQuad object in a lot of cases.

CCDXParticleSystemQuad is used as a static, so it is initialized just once for multiple CCParticleSystemQuads. As m_uMaxTotalParticles was almost useless - some internal buffers have been initialized just once (by CCDXParticleSystemQuad::initVertexAndIndexBuffer), so there was a buffer overflow in case if a small buffer (e.g. for 20 particles) has been initialized originally, and later another CCParticleQuad with more particles (but less than 100, for example 50) tried to be handled - CCDXParticleSystemQuad::RenderVertexBuffer overflow buffer by rewriting the originally allocated memory with more data.

Consequences - random crashes (if DirectX driver has no protection against buffer overflow), display flickering and so on. E.g. it was possible that some CCParticleSystemQuads were not shown at all, some are shown particularly (as less indices were provided than needed).

Such behaviour is fixed by this pull request. m_uMaxTotalParticles is used now as the currently allocated buffer size, and buffers are dynamically reallocated when it is needed. No indexes are lost, no memory corruption.

3 commits:
1) Test is created for the bug. Should be started from tests app: BugsTests - Particle Buffer Overflow before any other particles are created.
2) Fix for the buffer overflow itself.
3) Some potential memory leaks are fixed.
