### PR TITLE
Support for devices with ResolutionScale + some minor fixes

### DIFF
--- a/HelloWorld/win8_metro/HelloWorld.vcxproj
+++ b/HelloWorld/win8_metro/HelloWorld.vcxproj
@@ -262,6 +262,8 @@
     <ClInclude Include="..\..\cocos2dx\platform\win8_metro\DirectXHelper.h" />
     <ClInclude Include="..\..\cocos2dx\platform\win8_metro\DirectXRender.h" />
     <ClInclude Include="..\..\cocos2dx\platform\win8_metro\DXTextPainter.h" />
+    <ClInclude Include="..\..\cocos2dx\platform\win8_metro\FontFileStream.h" />
+    <ClInclude Include="..\..\cocos2dx\platform\win8_metro\FontLoader.h" />
     <ClInclude Include="..\..\cocos2dx\support\base64.h" />
     <ClInclude Include="..\..\cocos2dx\support\CCProfiling.h" />
     <ClInclude Include="..\..\cocos2dx\support\ccUtils.h" />
@@ -398,6 +400,8 @@
     <ClCompile Include="..\..\cocos2dx\platform\win8_metro\CCEGLView_win8_metro.cpp" />
     <ClCompile Include="..\..\cocos2dx\platform\win8_metro\DirectXRender.cpp" />
     <ClCompile Include="..\..\cocos2dx\platform\win8_metro\DXTextPainter.cpp" />
+    <ClCompile Include="..\..\cocos2dx\platform\win8_metro\FontFileStream.cpp" />
+    <ClCompile Include="..\..\cocos2dx\platform\win8_metro\FontLoader.cpp" />
     <ClCompile Include="..\..\cocos2dx\script_support\CCScriptSupport.cpp" />
     <ClCompile Include="..\..\cocos2dx\sprite_nodes\CCAnimation.cpp" />
     <ClCompile Include="..\..\cocos2dx\sprite_nodes\CCAnimationCache.cpp" />

--- a/HelloWorld/win8_metro/HelloWorld.vcxproj.filters
+++ b/HelloWorld/win8_metro/HelloWorld.vcxproj.filters
@@ -505,6 +505,12 @@
     <ClInclude Include="..\..\cocos2dx\platform\win8_metro\DXTextPainter.h">
       <Filter>cocos2dx\platform\win8_metro</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\cocos2dx\platform\win8_metro\FontFileStream.h">
+      <Filter>cocos2dx\platform\win8_metro</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cocos2dx\platform\win8_metro\FontLoader.h">
+      <Filter>cocos2dx\platform\win8_metro</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\cocos2dx\platform\win8_metro\BasicLoader.h">
       <Filter>cocos2dx\platform\win8_metro</Filter>
     </ClInclude>
@@ -931,6 +937,12 @@
       <Filter>CocosDenshion\win8_metro</Filter>
     </ClCompile>
     <ClCompile Include="..\..\cocos2dx\platform\win8_metro\DXTextPainter.cpp">
+      <Filter>cocos2dx\platform\win8_metro</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cocos2dx\platform\win8_metro\FontFileStream.cpp">
+      <Filter>cocos2dx\platform\win8_metro</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cocos2dx\platform\win8_metro\FontLoader.cpp">
       <Filter>cocos2dx\platform\win8_metro</Filter>
     </ClCompile>
     <ClCompile Include="..\..\cocos2dx\platform\win8_metro\BasicLoader.cpp">

--- a/cocos2dx/misc_nodes/CCProgressTimer.cpp
+++ b/cocos2dx/misc_nodes/CCProgressTimer.cpp
@@ -781,6 +781,7 @@ void CCDXProgressTimer::initVertexBuffer(ccV2F_C4B_T2F *vertexData,int& vertexDa
 	result = CCID3D11Device->CreateBuffer(&vertexBufferDesc, &vertexDataTmp, &m_vertexBuffer);
 	if(FAILED(result))
 	{
+		CC_SAFE_DELETE_ARRAY(vertices);
 		return ;
 	}
 

--- a/cocos2dx/platform/win8_metro/CCEGLView_win8_metro.cpp
+++ b/cocos2dx/platform/win8_metro/CCEGLView_win8_metro.cpp
@@ -41,6 +41,19 @@ NS_CC_BEGIN;
 
 static CCEGLView * s_pMainWindow;
 
+// helper function to get the proper resolution scale
+// (even if invalid value is received)
+static float GetResolutionScale()
+{
+    float ret = 1.0;
+    int resolutionScale = (int)Windows::Graphics::Display::DisplayProperties::ResolutionScale;
+    if (resolutionScale && resolutionScale != 100)
+    {
+        ret = (float)resolutionScale / 100;
+    }
+    return ret;
+}
+
 CCEGLView::CCEGLView()
 : m_pDelegate(NULL)
 , m_fScreenScaleFactor(1.0f)
@@ -209,6 +222,10 @@ void CCEGLView::setDesignResolution(int dx, int dy)
     DirectXRender^ render = DirectXRender::SharedDXRender();
     float winWidth = render->m_window->Bounds.Width;
     float winHeight = render->m_window->Bounds.Height;
+
+    // m_window size might be less than its real size due to ResolutionScale
+    winWidth *= GetResolutionScale();
+    winHeight *= GetResolutionScale();
 
     m_fScreenScaleFactor = min(winWidth / dx, winHeight / dy);
     m_fScreenScaleFactor *= CCDirector::sharedDirector()->getContentScaleFactor();
@@ -687,6 +704,9 @@ void CCEGLView::OnCharacterReceived(unsigned int keyCode)
 void CCEGLView::ConvertPointerCoords(float &x, float &y)
 {
 	float factor = CC_CONTENT_SCALE_FACTOR()/m_fScreenScaleFactor;
+	// received coord are calculated within original window (ResolutionScale)
+	x *= GetResolutionScale();
+	y *= GetResolutionScale();
 	x = (x / m_fWinScaleX - m_rcViewPort.left) * factor;
 	y = (y / m_fWinScaleY - m_rcViewPort.top) * factor;
 }

--- a/cocos2dx/platform/win8_metro/CCEGLView_win8_metro.cpp
+++ b/cocos2dx/platform/win8_metro/CCEGLView_win8_metro.cpp
@@ -684,6 +684,13 @@ void CCEGLView::OnCharacterReceived(unsigned int keyCode)
     }
 }
 
+void CCEGLView::ConvertPointerCoords(float &x, float &y)
+{
+	float factor = CC_CONTENT_SCALE_FACTOR()/m_fScreenScaleFactor;
+	x = (x / m_fWinScaleX - m_rcViewPort.left) * factor;
+	y = (y / m_fWinScaleY - m_rcViewPort.top) * factor;
+}
+
 void CCEGLView::OnPointerPressed(int id, const CCPoint& point)
 {
     // prepare CCTouch
@@ -705,9 +712,10 @@ void CCEGLView::OnPointerPressed(int id, const CCPoint& point)
     if (! pTouch || ! pSet)
         return;
 
-	float factor = CC_CONTENT_SCALE_FACTOR()/m_fScreenScaleFactor;
-    pTouch->SetTouchInfo(0, (point.x / m_fWinScaleX - m_rcViewPort.left) *factor, 
-        (point.y - m_rcViewPort.top) / m_fScreenScaleFactor / m_fWinScaleY);
+    float x = point.x;
+    float y = point.y;
+    ConvertPointerCoords(x, y);
+    pTouch->SetTouchInfo(0, x, y);
     pSet->addObject(pTouch);
 
     m_pDelegate->touchesBegan(pSet, NULL);
@@ -721,10 +729,10 @@ void CCEGLView::OnPointerReleased(int id, const CCPoint& point)
     if (! pTouch || ! pSet)
         return;
 
-	float factor = CC_CONTENT_SCALE_FACTOR()/m_fScreenScaleFactor;
-
-	pTouch->SetTouchInfo(0, (point.x / m_fWinScaleX - m_rcViewPort.left) *factor , 
-        (point.y - m_rcViewPort.top) / m_fScreenScaleFactor / m_fWinScaleY);
+    float x = point.x;
+    float y = point.y;
+    ConvertPointerCoords(x, y);
+    pTouch->SetTouchInfo(0, x, y);
 
     m_pDelegate->touchesEnded(pSet, NULL);
     pSet->removeObject(pTouch);
@@ -741,9 +749,11 @@ void CCEGLView::OnPointerMoved(int id, const CCPoint& point)
     if (! pTouch || ! pSet)
         return;
 
-	float factor = CC_CONTENT_SCALE_FACTOR()/m_fScreenScaleFactor;
-    pTouch->SetTouchInfo(0, (point.x / m_fWinScaleX - m_rcViewPort.left) *factor, 
-        (point.y - m_rcViewPort.top) / m_fScreenScaleFactor / m_fWinScaleY);
+    float x = point.x;
+    float y = point.y;
+    ConvertPointerCoords(x, y);
+    pTouch->SetTouchInfo(0, x, y);
+
     m_pDelegate->touchesMoved(pSet, NULL);
 }
 

--- a/cocos2dx/platform/win8_metro/CCEGLView_win8_metro.h
+++ b/cocos2dx/platform/win8_metro/CCEGLView_win8_metro.h
@@ -193,6 +193,7 @@ public:
     void OnPointerReleased(int id, const CCPoint& point);
     void OnPointerMoved(int id, const CCPoint& point);
 protected:
+    void ConvertPointerCoords(float &x, float &y);
 
 private:
     ID3D11Device1*           m_d3dDevice;

--- a/cocos2dx/platform/win8_metro/CCImage_win8_metro.cpp
+++ b/cocos2dx/platform/win8_metro/CCImage_win8_metro.cpp
@@ -76,7 +76,7 @@ bool CCImage::initWithString(
 			break;
 		}
 
-		pImageData = new unsigned char[(UINT)size.Width * (UINT)size.Height * 4];
+		pImageData = new unsigned char[pixelData->Length];
 		memcpy(pImageData,pixelData->Data,pixelData->Length);
 
 		CC_BREAK_IF(! pImageData);

--- a/cocos2dx/platform/win8_metro/DXTextPainter.cpp
+++ b/cocos2dx/platform/win8_metro/DXTextPainter.cpp
@@ -358,6 +358,9 @@ Platform::Array<byte>^  DXTextPainter::DrawTextToImage(Platform::String^ text, W
 
 	UINT uiWidth = (UINT)tSize->Width;
 	UINT uiHeight = (UINT)tSize->Height;
+	DX::ThrowIfFailed(
+		wicFormatConverter->GetSize(&uiWidth, &uiHeight)
+		);
 
 	UINT cbStride = uiWidth * 4;
 	UINT cbBufferSize = cbStride * uiHeight;
@@ -374,6 +377,11 @@ Platform::Array<byte>^  DXTextPainter::DrawTextToImage(Platform::String^ text, W
 		DX::ThrowIfFailed(
 			wicFormatConverter->CopyPixels(&rc, cbStride, cbBufferSize,pixelBuffer->Data)
 			);
+
+		// ensure that last bottom/right lines will not be lost - return the same size
+		// (which is used to draw text)
+		tSize->Width = (float)rc.Width;
+		tSize->Height = (float)rc.Height;
 	}
 
 	return pixelBuffer;

--- a/cocos2dx/platform/win8_metro/DXTextPainter.h
+++ b/cocos2dx/platform/win8_metro/DXTextPainter.h
@@ -42,10 +42,10 @@ enum class TextAlignment
 
 ref class DXTextPainter
 {
+	~DXTextPainter();
 public:
 	internal:
 		DXTextPainter();
-		~DXTextPainter();
 
 	void Initialize(
 		_In_ ID2D1DeviceContext*  d2dContext,


### PR DESCRIPTION
Hi,

Win8 supports ResolutionScale property to improve UX for high-density displays:
http://msdn.microsoft.com/en-us/library/windows/apps/hh465362.aspx
http://msdn.microsoft.com/en-us/library/windows/apps/windows.graphics.display.resolutionscale

It means that for 10.6" 2560x1440 display it will report the full window size as 1422x800 (180% less, can be checked with simulator - start simulator, change resolution and start your app). The similar - for 10.6" 1920x1080 it will be 140% less, for example. Some other cases are possible with other resolutions.

So the current cocos2d version does not handle it properly, and uses just a part of available screen space to show the data. This pull request is intended to fix the issue and improve the situation.

As a part of the fix - pointer press events are fixed (it was possible before that the coord is calculated incorrectly in some cases).

Also here is some other fixes:
- HelloWorld compilation is fixed (FontLoader.cpp and FontFileStream.cpp added to the project file)
- Pontential memory fix in case of DirectX call fail in 1 place
- Latest release SDK does not compile DXTextPainter.h due to:
  dxtextpainter.h(48): error C2035: a non-virtual destructor with 'internal' accessibility is not allowed for this type...
  a non-virtual destructor must have 'protected private' or 'private' accessibility
- Text drawing - do not lose the edge line on bottom/right - as floating point is widely used, it was possible that last visible line was lost with bitmap data.
