### PR TITLE
Text drawing - a fix for the case with provided width only

### DIFF
--- a/cocos2dx/platform/win8_metro/DXTextPainter.cpp
+++ b/cocos2dx/platform/win8_metro/DXTextPainter.cpp
@@ -299,7 +299,11 @@ Platform::Array<byte>^  DXTextPainter::DrawTextToImage(Platform::String^ text, W
 		// Originally provided tSize (provided with an original resolution)
 		// will be used - so layoutTextSize should be calculated.
 		layoutTextSize.Width = tSize->Width / GetResolutionScale();
-		layoutTextSize.Height = tSize->Height / GetResolutionScale();
+		// adjust height just in case if it is provided
+		if (tSize->Height > 0)
+		{
+			layoutTextSize.Height = tSize->Height / GetResolutionScale();
+		}
 	}
 
 	if(tSize->Height <=0)


### PR DESCRIPTION
If a width only was provided - it was possible that the text height will be lost, and for the case of 'Center' alignment it means that it would be centered around the 1st line also - just 2nd part of the text will be visible.

Fixed by an additional check to prevent such situation.

(for me it looks like a bug in DirectX if really, but perhaps it is done so due to compatibility issues)
