### PR TITLE
crash fix: on Cocosdension test

### DIFF
--- a/CocosDenshion/win8_metro/Audio.cpp
+++ b/CocosDenshion/win8_metro/Audio.cpp
@@ -458,7 +458,7 @@ void Audio::PreloadSoundEffect(const char* pszFilePath, bool isMusic)
 	{
 		if (m_soundEffects[sound].m_soundEffectBufferData)
 		{
-			delete m_soundEffects[sound].m_soundEffectBufferData;
+			delete[] m_soundEffects[sound].m_soundEffectBufferData;
 			m_soundEffects[sound].m_soundEffectBufferData = NULL;
 		}
 	}

--- a/CocosDenshion/win8_metro/Audio.h
+++ b/CocosDenshion/win8_metro/Audio.h
@@ -85,7 +85,6 @@ private:
     StreamingVoiceContext       m_voiceContext;
 
     typedef std::map<unsigned int, SoundEffectData> EffectList;
-    typedef std::pair<unsigned int, SoundEffectData> Effect;
 	EffectList				    m_soundEffects;         // “Ù–ß¡–±Ì
 
     unsigned int                m_backgroundID;         // ±≥æ∞“Ù¿÷

--- a/CocosDenshion/win8_metro/SimpleAudioEngine.cpp
+++ b/CocosDenshion/win8_metro/SimpleAudioEngine.cpp
@@ -9,13 +9,18 @@ using namespace std;
 namespace CocosDenshion {
 
 Audio* s_audioController = NULL;
+// a flag that if the s_audioController should be re-initialiezed
+// see also in SimpleAudioEngine::end() in this file
+bool s_bAudioControllerNeedReInitialize = true;
+
 static Audio* sharedAudioController()
 {
-    if (! s_audioController)
+    if ((! s_audioController) || s_bAudioControllerNeedReInitialize)
     {
         s_audioController = new Audio;
         s_audioController->Initialize();
         s_audioController->CreateResources();
+		s_bAudioControllerNeedReInitialize = false;
     }
 
     return s_audioController;
@@ -41,6 +46,8 @@ void SimpleAudioEngine::end()
     sharedAudioController()->StopBackgroundMusic(true);
     sharedAudioController()->StopAllSoundEffects();
     sharedAudioController()->ReleaseResources();
+	//set here to tell the s_bAudioControllerNeedReInitialize should be re-initialized
+	s_bAudioControllerNeedReInitialize = true;
 }
 
 void SimpleAudioEngine::setResource(const char* pszZipFileName)


### PR DESCRIPTION
after you calls the SimpleAudioEngine::end() ,then the s_audioController will never re-initialized., so we  should flag it to tell the s_audioController  should re-initialed its self.
